### PR TITLE
Update Firefox compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Minimalism and staying close and bounded to the standards.
 
 ## Compatibility
 
-Compo is not transpiled to old JavaScript and _really_ based upon Web Components so it only works out of the box on recent Chrome. It works almost on Firefox but still needs a flag to be set.
+Compo is not transpiled to old JavaScript and _really_ based upon Web Components so it only works out of the box on recent Chrome. It's also working quite well on Firefox 63.0 without any flag.
 
 It's planned to have a compatibility build using polyfills.
 


### PR DESCRIPTION
Using Firefox 63.0, `dom.webcomponents.customelements.enabled` and `dom.webcomponents.shadowdom.enabled` are both set to `true` by default.

I don't know about `dom.webcomponents.shadowdom.report_usage` but it's still `false`.

I tried the counter and 2048 examples (on 62.0.3 and 63.0) that are now working on a local environment.
It doesn't seem to work on CodeSanbox though...